### PR TITLE
Windows compatibility and usability fixes

### DIFF
--- a/app/app.scss
+++ b/app/app.scss
@@ -26,6 +26,8 @@ $colorWhiteTextDisabled: rgba(#fff, .5);
 $colorTooltipBackground: #263238;
 $colorTooltipText: #fff;
 
+$appBackground: #fff;
+
 $thinBorderColor: rgba(#000, .12);
 
 $hueIconWidth: 14px;
@@ -45,6 +47,7 @@ body {
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   cursor: default;
+  background: $appBackground;
 }
 
 * {
@@ -64,6 +67,9 @@ body {
   right: 12px;
   top: 8px;
   z-index: 100;
+  &, & * {
+    -webkit-app-region: no-drag;
+  }
 
   svg {
     fill: $colorBlackTextDisabled;
@@ -105,6 +111,9 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  &, & *{
+    -webkit-app-region: no-drag;
+  }
 
   &:hover .hue-label {
     display: block;

--- a/app/main.js
+++ b/app/main.js
@@ -27,6 +27,7 @@ const UPDATE_FEED_URL = 'http://roman-update-service.appspot.com/s/check_updates
 
 const DEV_MODE = argv.dev;
 
+const IS_IOS = process.platform == 'darwin';
 
 let isTrayMode = true;
 let mainWindow;
@@ -116,16 +117,20 @@ function updateUiMode() {
     });
   }
 
-  menuItems.push({
-    label: isTrayMode ? 'Switch to Normal App Mode' : 'Switch to Menu Bar Mode',
-    click: () => {
-      isTrayMode = !isTrayMode;
-      updateUiMode();
-    }
-  });
+  if (IS_IOS) {
+    menuItems.push({
+      label: isTrayMode ? 'Switch to Normal App Mode' : 'Switch to Menu Bar Mode',
+      click: () => {
+        isTrayMode = !isTrayMode;
+        updateUiMode();
+      }
+    });
+  }
 
   menuItems.push({ type: 'separator' });
-  menuItems.push({ label: 'About ' + app.getName(), role: 'about' });
+  if (IS_IOS) {
+    menuItems.push({label: 'About ' + app.getName(), role: 'about'});
+  }
 
   if (isTrayMode) {
     menuItems.push({ label: 'Quit', click: () => app.quit() });


### PR DESCRIPTION
- Selection of hues
- Hiding the main window
- Background color of the app
- OS X feature based menu items has been removed
 (About and switching between app modes)

This fixes https://github.com/romannurik/MaterialColorsApp/issues/11

Signed-off-by: tamas.kiss <kisstkondoros@gmail.com>