### PR TITLE
Support running without global packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If you want to customize the app for your own needs, you can do a custom build.
 
         $ npm install
 
-  3. To run the app (you can install gulp using `npm install --global gulp-cli`):
+  3. To run the app:
 
-        $ gulp
+        $ npm start
 
 Note that you'll probably want to disable the auto-updating mechanism by emptying out the `checkForUpdates` method in
 [main.js](https://github.com/romannurik/MaterialColorsApp/blob/master/app/main.js).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "main": "main.js",
   "author": "Roman Nurik",
   "private": true,
+  "scripts": {
+    "start": "gulp"
+  },
   "devDependencies": {
     "del": "^2.2.0",
     "electron-osx-sign": "^0.3.0",
@@ -15,6 +18,7 @@
     "electron-prebuilt": "^0.37.1",
     "gulp": "^3.9.1",
     "gulp-cache": "^0.4.2",
+    "gulp-cli": "^1.2.1",
     "gulp-load-plugins": "^1.2.0",
     "gulp-plist": "^0.1.0",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
This change:
* installs `gulp-cli` locally
* adds an npm script for starting the app by calling `gulp`
* udpates the README